### PR TITLE
Fix onload content from showing 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -48,6 +48,7 @@ body {
   clear: both;
   font-weight: 500;
   font-size: 1.75em;
+  opacity: 0;
 }
 .quote-box .quote-text i {
   font-size: 1.0em;
@@ -60,6 +61,7 @@ body {
   padding-top: 20px;
   font-size: 1em;
   text-align: right;
+  opacity: 0;
 }
 .quote-box .buttons {
   width: 450px;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 <div class="quote-box">
   <div class="quote-text">
-    <i class="fa fa-quote-left"> </i><span id="text"></span>
+    <i class="fa fa-quote-left"> </i><span id="text"></span> <i class="fa fa-quote-right"></i>
   </div>
   <div class="quote-author">
     - <span id="author"></span>


### PR DESCRIPTION
I noticed that some content was showing when you first load the page:
<img width="1027" alt="quotegenbug" src="https://cloud.githubusercontent.com/assets/10105509/19017062/77f76812-87e2-11e6-9a42-1cd35734fc77.png">

Added an initial opacity to the quote content divs so it would animate in when you call `getQuote()`.
Also included the right quote!
